### PR TITLE
Add topbar extension, custom theme manager and support for settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@jupyterlab/rendermime": "^2.0.2",
     "@jupyterlab/services": "^5.0.2",
     "@jupyterlab/settingregistry": "^2.0.1",
+    "@jupyterlab/shortcuts-extension": "^2.0.2",
     "@jupyterlab/theme-dark-extension": "^2.0.2",
     "@jupyterlab/theme-light-extension": "^2.0.2",
     "@jupyterlab/ui-components": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@jupyterlab/application": "^2.0.2",
     "@jupyterlab/apputils": "^2.0.2",
+    "@jupyterlab/apputils-extension": "^2.0.2",
     "@jupyterlab/cells": "^2.0.2",
     "@jupyterlab/codemirror": "^2.0.2",
     "@jupyterlab/completer": "^2.0.2",
@@ -43,6 +44,7 @@
     "@jupyterlab/observables": "^3.0.1",
     "@jupyterlab/rendermime": "^2.0.2",
     "@jupyterlab/services": "^5.0.2",
+    "@jupyterlab/settingregistry": "^2.0.1",
     "@jupyterlab/theme-dark-extension": "^2.0.2",
     "@jupyterlab/theme-light-extension": "^2.0.2",
     "@jupyterlab/ui-components": "^2.0.2",
@@ -52,9 +54,13 @@
     "@lumino/disposable": "^1.3.5",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
+    "jupyterlab-topbar-extension": "^0.5.0",
+    "jupyterlab-theme-toggle": "^0.5.0",
     "es6-promise": "~4.2.8",
     "mock-socket": "^9.0.3",
-    "p5": "^1.0.0"
+    "p5": "^1.0.0",
+    "react": "~16.9.0",
+    "react-dom": "~16.9.0"
   },
   "devDependencies": {
     "@types/codemirror": "^0.0.76",
@@ -82,6 +88,10 @@
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
+  },
+  "resolutions": {
+    "react": "~16.9.0",
+    "react-dom": "~16.9.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "mock-socket": "^9.0.3",
     "p5": "^1.0.0",
     "react": "~16.9.0",
-    "react-dom": "~16.9.0"
+    "react-dom": "~16.9.0",
+    "strip-json-comments": "^3.0.1"
   },
   "devDependencies": {
     "@types/codemirror": "^0.0.76",

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -38,6 +38,9 @@ export class App extends JupyterFrontEnd<Shell> {
    */
   readonly version = 'unknown';
 
+  /**
+   * The JupyterLab application paths dictionary.
+   */
   get paths(): JupyterFrontEnd.IPaths {
     return {
       urls: {

--- a/src/app/plugins/theme/index.ts
+++ b/src/app/plugins/theme/index.ts
@@ -1,11 +1,17 @@
-import { IThemeManager } from '@jupyterlab/apputils';
-
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
+import { IThemeManager } from '@jupyterlab/apputils';
+
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
 import { ThemeManager } from '../theme/manager';
+
+namespace CommandIDs {
+  export const changeTheme = 'apputils:change-theme';
+}
 
 /**
  * The theme plugin.
@@ -14,8 +20,38 @@ const plugin: JupyterFrontEndPlugin<IThemeManager> = {
   id: '@jupyterlab/apputils-extension:themes',
   autoStart: true,
   provides: IThemeManager,
-  activate: (app: JupyterFrontEnd): IThemeManager => {
-    const manager = new ThemeManager();
+  requires: [ISettingRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    settings: ISettingRegistry
+  ): IThemeManager => {
+    const host = app.shell;
+    const commands = app.commands;
+    const key = plugin.id;
+    const manager = new ThemeManager({
+      key,
+      host,
+      settings,
+      splash: undefined,
+      url: ''
+    });
+
+    let currentTheme: string;
+    commands.addCommand(CommandIDs.changeTheme, {
+      label: args => {
+        const theme = args['theme'] as string;
+        return args['isPalette'] ? `Use ${theme} Theme` : theme;
+      },
+      isToggled: args => args['theme'] === currentTheme,
+      execute: args => {
+        const theme = args['theme'] as string;
+        if (theme === manager.theme) {
+          return;
+        }
+        return manager.setTheme(theme);
+      }
+    });
+
     return manager;
   }
 };

--- a/src/app/plugins/theme/index.ts
+++ b/src/app/plugins/theme/index.ts
@@ -36,13 +36,7 @@ const plugin: JupyterFrontEndPlugin<IThemeManager> = {
       url: ''
     });
 
-    let currentTheme: string;
     commands.addCommand(CommandIDs.changeTheme, {
-      label: args => {
-        const theme = args['theme'] as string;
-        return args['isPalette'] ? `Use ${theme} Theme` : theme;
-      },
-      isToggled: args => args['theme'] === currentTheme,
       execute: args => {
         const theme = args['theme'] as string;
         if (theme === manager.theme) {

--- a/src/app/plugins/theme/index.ts
+++ b/src/app/plugins/theme/index.ts
@@ -9,6 +9,9 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import { ThemeManager } from '../theme/manager';
 
+/**
+ * The command IDs used by the plugin.
+ */
 namespace CommandIDs {
   export const changeTheme = 'apputils:change-theme';
 }

--- a/src/app/plugins/theme/manager.ts
+++ b/src/app/plugins/theme/manager.ts
@@ -22,6 +22,13 @@ const DARK_THEME = (darkThemeVars as string) + (darkTheme as string);
  *
  */
 export class ThemeManager extends LabThemeManager {
+  /**
+   * Register a theme with the theme manager.
+   *
+   * @param theme - The theme to register.
+   *
+   * @returns A disposable that can be used to unregister the theme.
+   */
   register(theme: IThemeManager.ITheme): IDisposable {
     const { name } = theme;
 
@@ -33,6 +40,11 @@ export class ThemeManager extends LabThemeManager {
     });
   }
 
+  /**
+   * Load a theme CSS file by theme name.
+   *
+   * @param name The name of the theme.
+   */
   private async _loadCSS(name: string): Promise<void> {
     const style = document.createElement('style');
     if (name === 'JupyterLab Dark') {

--- a/src/app/plugins/theme/manager.ts
+++ b/src/app/plugins/theme/manager.ts
@@ -14,8 +14,6 @@ import darkThemeVars from '!!raw-loader!@jupyterlab/theme-dark-extension/style/v
 const LIGHT_THEME = (lightThemeVars as string) + (lightTheme as string);
 const DARK_THEME = (darkThemeVars as string) + (darkTheme as string);
 
-let count = 0;
-
 /**
  * A class that provides theme management.
  *
@@ -37,7 +35,7 @@ export class ThemeManager extends LabThemeManager {
 
   private async _loadCSS(name: string): Promise<void> {
     const style = document.createElement('style');
-    if (count++ % 2 === 0) {
+    if (name === 'JupyterLab Dark') {
       style.textContent = DARK_THEME;
     } else {
       style.textContent = LIGHT_THEME;

--- a/src/app/plugins/theme/manager.ts
+++ b/src/app/plugins/theme/manager.ts
@@ -1,10 +1,20 @@
-import { IThemeManager } from '@jupyterlab/apputils';
+import {
+  ThemeManager as LabThemeManager,
+  IThemeManager
+} from '@jupyterlab/apputils';
 
-import { IChangedArgs } from '@jupyterlab/coreutils';
+import { IDisposable } from '@lumino/disposable';
 
-import { IDisposable, DisposableSet } from '@lumino/disposable';
+import lightTheme from '!!raw-loader!@jupyterlab/theme-light-extension/style/index.css';
+import lightThemeVars from '!!raw-loader!@jupyterlab/theme-light-extension/style/variables.css';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import darkTheme from '!!raw-loader!@jupyterlab/theme-dark-extension/style/index.css';
+import darkThemeVars from '!!raw-loader!@jupyterlab/theme-dark-extension/style/variables.css';
+
+const LIGHT_THEME = (lightThemeVars as string) + (lightTheme as string);
+const DARK_THEME = (darkThemeVars as string) + (darkTheme as string);
+
+let count = 0;
 
 /**
  * A class that provides theme management.
@@ -12,85 +22,33 @@ import { ISignal, Signal } from '@lumino/signaling';
  * Note: Custom Theme Manager than core JupyterLab to be
  * able to override the `loadCSS` method.
  *
- * TODO: extends from upstream ThemeManager?
  */
-export class ThemeManager implements IThemeManager {
-  /**
-   * Get the name of the current theme.
-   */
-  get theme(): string | null {
-    return '';
-  }
-
-  /**
-   * The names of the registered themes.
-   */
-  get themes(): string[] {
-    return [];
-  }
-
-  /**
-   * A signal fired when the application theme changes.
-   */
-  get themeChanged(): ISignal<
-    this,
-    IChangedArgs<string, string | null, string>
-  > {
-    return this._themeChanged;
-  }
-
-  /**
-   * Load a theme CSS file by path.
-   *
-   * @param path - The path of the file to load.
-   */
-  async loadCSS(path: string): Promise<void> {
-    console.log('loadCSS');
-  }
-
-  /**
-   * Register a theme with the theme manager.
-   *
-   * @param theme - The theme to register.
-   *
-   * @returns A disposable that can be used to unregister the theme.
-   */
+export class ThemeManager extends LabThemeManager {
   register(theme: IThemeManager.ITheme): IDisposable {
-    console.log('register theme');
-    return new DisposableSet();
+    const { name } = theme;
+
+    return super.register({
+      ...theme,
+      name,
+      load: () => this._loadCSS(name),
+      unload: () => this._unloadCSS(name)
+    });
   }
 
-  /**
-   * Set the current theme.
-   *
-   * @param name The name of the theme.
-   */
-  async setTheme(name: string): Promise<void> {
-    console.log('setTheme');
+  private async _loadCSS(name: string): Promise<void> {
+    const style = document.createElement('style');
+    if (count++ % 2 === 0) {
+      style.textContent = DARK_THEME;
+    } else {
+      style.textContent = LIGHT_THEME;
+    }
+    document.body.appendChild(style);
+    this._style = style;
   }
 
-  /**
-   * Test whether a given theme is light.
-   *
-   * @param name The name of the theme.
-   */
-  isLight(name: string): boolean {
-    console.log('isLight');
-    return true;
+  private async _unloadCSS(name: string): Promise<void> {
+    this._style?.parentElement?.removeChild(this._style);
   }
 
-  /**
-   * Test whether a given theme styles scrollbars,
-   * and if the user has scrollbar styling enabled.
-   *
-   * @param name The name of the theme.
-   */
-  themeScrollbars(name: string): boolean {
-    console.log('isLight');
-    return true;
-  }
-
-  private _themeChanged = new Signal<this, IChangedArgs<string, string | null>>(
-    this
-  );
+  private _style: HTMLStyleElement;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ async function main(): Promise<void> {
     require('./app/plugins/notebook'),
     require('./app/plugins/theme'),
     require('./app/plugins/top'),
+    require('@jupyterlab/shortcuts-extension'),
     require('@jupyterlab/theme-dark-extension'),
     require('@jupyterlab/theme-light-extension'),
     require('jupyterlab-theme-toggle'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import {
   JupyterFrontEnd
 } from '@jupyterlab/application';
 
+import { settingsPlugin } from '@jupyterlab/apputils-extension/lib/settingsplugin';
+
 import { App } from './app/app';
 
 import '@jupyterlab/application/style/index.css';
@@ -17,8 +19,6 @@ import '@jupyterlab/completer/style/index.css';
 import '@jupyterlab/documentsearch/style/index.css';
 
 import '@jupyterlab/notebook/style/index.css';
-
-import '@jupyterlab/theme-light-extension/style/index.css';
 
 import '../style/index.css';
 
@@ -44,10 +44,13 @@ async function main(): Promise<void> {
     require('./app/plugins/theme'),
     require('./app/plugins/top'),
     require('@jupyterlab/theme-dark-extension'),
-    require('@jupyterlab/theme-light-extension')
+    require('@jupyterlab/theme-light-extension'),
+    require('jupyterlab-theme-toggle'),
+    require('jupyterlab-topbar-extension')
   ];
 
   app.registerPlugin(paths);
+  app.registerPlugin(settingsPlugin);
   app.registerPluginModules(mods);
 
   await app.start();

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -9,7 +9,11 @@ export class Router {
    * @param pattern The pattern
    * @param callback The callback
    */
-  add(method: Router.Method, pattern: string, callback: Router.Callback): void {
+  add(
+    method: Router.Method,
+    pattern: string | RegExp,
+    callback: Router.Callback
+  ): void {
     this._routes.push({
       method,
       pattern,
@@ -58,7 +62,7 @@ export namespace Router {
    */
   export interface IRoute {
     method: Method;
-    pattern: string;
+    pattern: string | RegExp;
     callback: Callback;
   }
 }

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -1,6 +1,40 @@
 import { JSONObject, JSONArray } from '@lumino/coreutils';
 
+import stripJsonComments from 'strip-json-comments';
+
 import { Router } from './router';
+
+import themesSchema from '@jupyterlab/apputils-extension/schema/themes.json';
+
+import topbarSchema from 'jupyterlab-topbar-extension/schema/plugin.json';
+
+import themeToggleSchema from 'jupyterlab-theme-toggle/schema/plugin.json';
+
+// TODO: type the settings
+// TODO: automatically load the settings from the list of plugins?
+const DEFAULT_SETTINGS = [
+  {
+    id: '@jupyterlab/apputils-extension:themes',
+    raw: '{}',
+    schema: themesSchema,
+    settings: {},
+    version: '2.0.2' // TODO: fetch from package.json
+  },
+  {
+    id: 'jupyterlab-topbar-extension:plugin',
+    raw: '{}',
+    schema: topbarSchema,
+    settings: {},
+    version: '2.0.2' // TODO: fetch from package.json
+  },
+  {
+    id: 'jupyterlab-theme-toggle:plugin',
+    raw: '{}',
+    schema: themeToggleSchema,
+    settings: {},
+    version: '2.0.2' // TODO: fetch from package.json
+  }
+];
 
 /**
  * A class to handle requests to /api/settings
@@ -10,20 +44,30 @@ export class Settings {
    * Construct a new Settings.
    */
   constructor() {
+    // TODO: better regex
     this._router.add('GET', '/api/settings/.+', async (req: Request) => {
-      const plugin = req.url.replace(Settings.SETTINGS_SERVICE_URL, '');
-      return new Response(JSON.stringify(this._get(plugin)));
+      const url = new URL(req.url);
+      const pluginId = url.pathname.replace(
+        `${Settings.SETTINGS_SERVICE_URL}/`,
+        ''
+      );
+      return new Response(JSON.stringify(this._get(pluginId)));
     });
     this._router.add(
       'GET',
       '/api/settings',
       async (req: Request) => new Response(JSON.stringify(this._getAll()))
     );
-    this._router.add(
-      'PUT',
-      '/api/settings/.+',
-      async (req: Request) => new Response(null, { status: 204 })
-    );
+    this._router.add('PUT', '/api/settings/.+', async (req: Request) => {
+      const url = new URL(req.url);
+      const pluginId = url.pathname.replace(
+        `${Settings.SETTINGS_SERVICE_URL}/`,
+        ''
+      );
+      const raw = await req.text();
+      localStorage.setItem(pluginId, raw);
+      return new Response(null, { status: 204 });
+    });
     this._router.add(
       'PUT',
       '/api/settings',
@@ -40,129 +84,26 @@ export class Settings {
   private _get(plugin: string): any {
     const all = this._getAll();
     const settings = all.settings as JSONArray;
-    return settings[0];
+    return settings.find((setting: JSONObject) => {
+      return setting['id'] === plugin;
+    });
   }
 
   /**
    * Get the settings
    */
   private _getAll(): JSONObject {
+    const settings = DEFAULT_SETTINGS.map(plugin => {
+      const { id } = plugin;
+      const raw = localStorage.getItem(id) ?? plugin.raw;
+      return {
+        ...plugin,
+        raw,
+        settings: JSON.parse(stripJsonComments(raw))
+      };
+    });
     return {
-      settings: [
-        {
-          id: '@jupyterlab/apputils-extension:themes',
-          raw:
-            '{\n    // Theme\n    // @jupyterlab/apputils-extension:themes\n    // Theme manager settings.\n    // *************************************\n\n    // Selected Theme\n    // Application-level visual styling theme\n    "theme": "JupyterLab Dark",\n\n    // Scrollbar Theming\n    // Enable/disable styling of the application scrollbars\n    "theme-scrollbars": true\n}',
-          schema: {
-            title: 'Theme',
-            'jupyter.lab.setting-icon-label': 'Theme Manager',
-            description: 'Theme manager settings.',
-            type: 'object',
-            additionalProperties: false,
-            definitions: {
-              cssOverrides: {
-                type: 'object',
-                additionalProperties: false,
-                description:
-                  "The description field of each item is the CSS property that will be used to validate an override's value",
-                properties: {
-                  'code-font-size': {
-                    type: ['string', 'null'],
-                    description: 'font-size'
-                  },
-                  'content-font-size1': {
-                    type: ['string', 'null'],
-                    description: 'font-size'
-                  },
-                  'ui-font-size1': {
-                    type: ['string', 'null'],
-                    description: 'font-size'
-                  }
-                }
-              }
-            },
-            properties: {
-              theme: {
-                type: 'string',
-                title: 'Selected Theme',
-                description: 'Application-level visual styling theme',
-                default: 'JupyterLab Dark'
-              },
-              'theme-scrollbars': {
-                type: 'boolean',
-                title: 'Scrollbar Theming',
-                description:
-                  'Enable/disable styling of the application scrollbars',
-                default: false
-              },
-              overrides: {
-                title: 'Theme CSS Overrides',
-                description:
-                  'Override theme CSS variables by setting key-value pairs here',
-                $ref: '#/definitions/cssOverrides',
-                default: {
-                  'code-font-size': null,
-                  'content-font-size1': null,
-                  'ui-font-size1': null
-                }
-              }
-            }
-          },
-          settings: {
-            theme: 'JupyterLab Dark',
-            'theme-scrollbars': true
-          },
-          version: '2.0.2'
-        },
-        {
-          id: 'jupyterlab-theme-toggle:plugin',
-          raw: '{}',
-          schema: {
-            'jupyter.lab.setting-icon-class': 'jp-SettingsIcon',
-            'jupyter.lab.setting-icon-label': 'Theme Toggle',
-            title: 'Theme Toggle',
-            description: 'Toggle the JupyterLab theme',
-            properties: {},
-            additionalProperties: false,
-            'jupyter.lab.shortcuts': [],
-            type: 'object'
-          },
-          settings: {},
-          version: '0.5.0'
-        },
-        {
-          id: 'jupyterlab-topbar-extension:plugin',
-          raw:
-            '{\n    // Top Bar Extension\n    // jupyterlab-topbar-extension:plugin\n    // Top Bar Extension\n    // **********************************\n\n    // Items Order\n    // Ordered list of the Top Bar items\n    "order": [\n        "spacer",\n        "memory"\n    ],\n\n    // Top Bar Visibility\n    // Whether the top bar is visible or not\n    "visible": true\n}',
-          schema: {
-            'jupyter.lab.setting-icon-class': 'jp-BuildIcon',
-            'jupyter.lab.setting-icon-label': 'Top Bar Extension',
-            title: 'Top Bar Extension',
-            description: 'Top Bar Extension',
-            properties: {
-              visible: {
-                title: 'Top Bar Visibility',
-                description: 'Whether the top bar is visible or not',
-                default: true,
-                type: 'boolean'
-              },
-              order: {
-                title: 'Items Order',
-                description: 'Ordered list of the Top Bar items',
-                default: [],
-                type: 'array'
-              }
-            },
-            additionalProperties: false,
-            type: 'object'
-          },
-          settings: {
-            order: ['spacer', 'memory'],
-            visible: true
-          },
-          version: '0.5.0'
-        }
-      ]
+      settings
     };
   }
 

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -8,6 +8,8 @@ import { Router } from './router';
 
 import themesSchema from '@jupyterlab/apputils-extension/schema/themes.json';
 
+import shortcutsSchema from '@jupyterlab/shortcuts-extension/schema/shortcuts.json';
+
 import topbarSchema from 'jupyterlab-topbar-extension/schema/plugin.json';
 
 import themeToggleSchema from 'jupyterlab-theme-toggle/schema/plugin.json';
@@ -137,6 +139,13 @@ const DEFAULT_SETTINGS: IPlugin[] = [
     id: '@jupyterlab/apputils-extension:themes',
     raw: '{}',
     schema: themesSchema as ISettingRegistry.ISchema,
+    settings: {},
+    version: '2.0.2' // TODO: fetch from package.json
+  },
+  {
+    id: '@jupyterlab/shortcuts-extension:shortcuts',
+    raw: '{}',
+    schema: shortcutsSchema as ISettingRegistry.ISchema,
     settings: {},
     version: '2.0.2' // TODO: fetch from package.json
   },

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -1,3 +1,5 @@
+import { JSONObject, JSONArray } from '@lumino/coreutils';
+
 import { Router } from './router';
 
 /**
@@ -8,19 +10,159 @@ export class Settings {
    * Construct a new Settings.
    */
   constructor() {
+    this._router.add('GET', '/api/settings/.+', async (req: Request) => {
+      const plugin = req.url.replace(Settings.SETTINGS_SERVICE_URL, '');
+      return new Response(JSON.stringify(this._get(plugin)));
+    });
     this._router.add(
       'GET',
       '/api/settings',
-      async (req: Request) => new Response(JSON.stringify(this._get()))
+      async (req: Request) => new Response(JSON.stringify(this._getAll()))
     );
+    this._router.add(
+      'PUT',
+      '/api/settings/.+',
+      async (req: Request) => new Response(null, { status: 204 })
+    );
+    this._router.add(
+      'PUT',
+      '/api/settings',
+      async (req: Request) => new Response(null, { status: 204 })
+    );
+  }
+
+  /**
+   * Get settings by plugin name
+   *
+   * @param plugin the name of the plugin
+   *
+   */
+  private _get(plugin: string): any {
+    const all = this._getAll();
+    const settings = all.settings as JSONArray;
+    return settings[0];
   }
 
   /**
    * Get the settings
    */
-  private _get(): any {
+  private _getAll(): JSONObject {
     return {
-      settings: []
+      settings: [
+        {
+          id: '@jupyterlab/apputils-extension:themes',
+          raw:
+            '{\n    // Theme\n    // @jupyterlab/apputils-extension:themes\n    // Theme manager settings.\n    // *************************************\n\n    // Selected Theme\n    // Application-level visual styling theme\n    "theme": "JupyterLab Dark",\n\n    // Scrollbar Theming\n    // Enable/disable styling of the application scrollbars\n    "theme-scrollbars": true\n}',
+          schema: {
+            title: 'Theme',
+            'jupyter.lab.setting-icon-label': 'Theme Manager',
+            description: 'Theme manager settings.',
+            type: 'object',
+            additionalProperties: false,
+            definitions: {
+              cssOverrides: {
+                type: 'object',
+                additionalProperties: false,
+                description:
+                  "The description field of each item is the CSS property that will be used to validate an override's value",
+                properties: {
+                  'code-font-size': {
+                    type: ['string', 'null'],
+                    description: 'font-size'
+                  },
+                  'content-font-size1': {
+                    type: ['string', 'null'],
+                    description: 'font-size'
+                  },
+                  'ui-font-size1': {
+                    type: ['string', 'null'],
+                    description: 'font-size'
+                  }
+                }
+              }
+            },
+            properties: {
+              theme: {
+                type: 'string',
+                title: 'Selected Theme',
+                description: 'Application-level visual styling theme',
+                default: 'JupyterLab Dark'
+              },
+              'theme-scrollbars': {
+                type: 'boolean',
+                title: 'Scrollbar Theming',
+                description:
+                  'Enable/disable styling of the application scrollbars',
+                default: false
+              },
+              overrides: {
+                title: 'Theme CSS Overrides',
+                description:
+                  'Override theme CSS variables by setting key-value pairs here',
+                $ref: '#/definitions/cssOverrides',
+                default: {
+                  'code-font-size': null,
+                  'content-font-size1': null,
+                  'ui-font-size1': null
+                }
+              }
+            }
+          },
+          settings: {
+            theme: 'JupyterLab Dark',
+            'theme-scrollbars': true
+          },
+          version: '2.0.2'
+        },
+        {
+          id: 'jupyterlab-theme-toggle:plugin',
+          raw: '{}',
+          schema: {
+            'jupyter.lab.setting-icon-class': 'jp-SettingsIcon',
+            'jupyter.lab.setting-icon-label': 'Theme Toggle',
+            title: 'Theme Toggle',
+            description: 'Toggle the JupyterLab theme',
+            properties: {},
+            additionalProperties: false,
+            'jupyter.lab.shortcuts': [],
+            type: 'object'
+          },
+          settings: {},
+          version: '0.5.0'
+        },
+        {
+          id: 'jupyterlab-topbar-extension:plugin',
+          raw:
+            '{\n    // Top Bar Extension\n    // jupyterlab-topbar-extension:plugin\n    // Top Bar Extension\n    // **********************************\n\n    // Items Order\n    // Ordered list of the Top Bar items\n    "order": [\n        "spacer",\n        "memory"\n    ],\n\n    // Top Bar Visibility\n    // Whether the top bar is visible or not\n    "visible": true\n}',
+          schema: {
+            'jupyter.lab.setting-icon-class': 'jp-BuildIcon',
+            'jupyter.lab.setting-icon-label': 'Top Bar Extension',
+            title: 'Top Bar Extension',
+            description: 'Top Bar Extension',
+            properties: {
+              visible: {
+                title: 'Top Bar Visibility',
+                description: 'Whether the top bar is visible or not',
+                default: true,
+                type: 'boolean'
+              },
+              order: {
+                title: 'Items Order',
+                description: 'Ordered list of the Top Bar items',
+                default: [],
+                type: 'array'
+              }
+            },
+            additionalProperties: false,
+            type: 'object'
+          },
+          settings: {
+            order: ['spacer', 'memory'],
+            visible: true
+          },
+          version: '0.5.0'
+        }
+      ]
     };
   }
 

--- a/style/index.css
+++ b/style/index.css
@@ -1,5 +1,4 @@
 body {
-  background: white;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
This reuses plugins from the [topbar extension](https://github.com/jtpio/jupyterlab-topbar), including one to toggle the theme between light and dark.

The settings are persisted to `localStorage`.

![settings-topbar](https://user-images.githubusercontent.com/591645/77823810-3c116b00-70fe-11ea-836e-4a4d94df9537.gif)
