### PR TITLE
Make the notebook toolbar scrollable

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -70,3 +70,7 @@ iframe {
   border-radius: 2px;
   word-break: break-all;
 }
+
+.jp-NotebookPanel-toolbar {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
So the right elements in the toolbar can be used on mobile.

![toolbar-scroll](https://user-images.githubusercontent.com/591645/81616245-718ac300-93e3-11ea-80ef-a06bf62de3e8.gif)
