### PR TITLE
Expose p5.sound by default

### DIFF
--- a/src/server/kernel.ts
+++ b/src/server/kernel.ts
@@ -6,6 +6,8 @@ import { IDisposable } from '@lumino/disposable';
 
 import p5 from '!!raw-loader!p5/lib/p5.min.js';
 
+import p5Sound from '!!raw-loader!p5/lib/addons/p5.sound.min.js';
+
 import { IJupyterServer } from '../tokens';
 
 /**
@@ -467,10 +469,19 @@ export class KernelIFrame implements IJupyterServer.IKernelIFrame, IDisposable {
       return;
     }
     const doc = iframe.contentWindow.document;
+
+    // add p5
     const script = doc.createElement('script');
     doc.body.appendChild(script);
     script.textContent = p5 as string;
     script.id = 'p5-src';
+
+    // add p5-sound
+    const soundScript = doc.createElement('script');
+    doc.body.appendChild(soundScript);
+    soundScript.textContent = p5Sound as string;
+    soundScript.id = 'p5-sound';
+
     this._evalFunc(
       iframe.contentWindow,
       `


### PR DESCRIPTION
To be able to use the audio addon out of the box.

![p5-sound](https://user-images.githubusercontent.com/591645/82505266-8959f980-9afd-11ea-9dc9-8d07b1a0bd64.gif)

```javascript
var fft, sound;

function preload() {
  sound = loadSound('http://localhost:9999/sketches/sound-loop/loop-32.wav');
}

function setup() {
  createCanvas(innerWidth, innerHeight);
  sound.play();
  fft = new p5.FFT();
}

function draw() {
  background(220);

  const spectrum = fft.analyze();
  noStroke();
  fill(255, 0, 255);
  for (let i = 0; i< spectrum.length; i++){
    let x = map(i, 0, spectrum.length, 0, width);
    let h = -height + map(spectrum[i], 0, 255, height, 0);
    rect(x, height, width / spectrum.length, h )
  }

  const waveform = fft.waveform();
  noFill();
  beginShape();
  stroke(20);
  for (let i = 0; i < waveform.length; i++){
    let x = map(i, 0, waveform.length, 0, width);
    let y = map( waveform[i], -1, 1, 0, height);
    vertex(x,y);
  }
  endShape();
}
```