### PR TITLE
Disable retro logo from the `@jupyterlite` app

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -6,7 +6,7 @@
     "collaborative": true,
     "disabledExtensions": [
       "@jupyterlab/application-extension:logo",
-      "@retrolab/application-extension:logo",
+      "@jupyterlite/retro-application-extension:logo",
       "@jupyterlite/application-extension:logo",
       "@jupyterlite/retro-application-extension:logo",
       "@jupyterlite/javascript-kernel-extension",


### PR DESCRIPTION
Instead of the `@retrolab` one which is not used in JupyterLite.