### PR TITLE
Update to `jupyterlite==0.1.0a14`

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -4,8 +4,8 @@ jupyterlab-language-pack-fr-FR
 jupyterlab-language-pack-it-IT
 jupyterlab-language-pack-pl-PL
 jupyterlab-language-pack-zh-CN
-jupyterlite==0.1.0a12
-jupyterlite-p5-kernel==0.1.0a11
+jupyterlite==0.1.0a14
+jupyterlite-p5-kernel==0.1.0a12
 
 # install the extra extensions
 .


### PR DESCRIPTION
Which should fix the issue with the kernel logos.

![image](https://user-images.githubusercontent.com/591645/137377567-b72b98c2-deab-47af-a7c5-c8c39d733a88.png)

![image](https://user-images.githubusercontent.com/591645/137377605-8e3498f7-6c02-40c2-a412-d0b1bab648bb.png)
