### PR TITLE
Depend on `jupyterlite-core`

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -8,9 +8,7 @@
       "@jupyterlab/application-extension:logo",
       "@jupyterlite/retro-application-extension:logo",
       "@jupyterlite/application-extension:logo",
-      "@jupyterlite/retro-application-extension:logo",
-      "@jupyterlite/javascript-kernel-extension",
-      "@jupyterlite/pyolite-kernel-extension"
+      "@jupyterlite/retro-application-extension:logo"
     ],
     "faviconUrl": "./lab/favicon.ico"
   }

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,11 +1,11 @@
-jupyterlab~=3.5.2
+jupyterlab~=3.5.3
 jupyterlab-language-pack-es-ES
 jupyterlab-language-pack-fr-FR
 jupyterlab-language-pack-it-IT
 jupyterlab-language-pack-pl-PL
 jupyterlab-language-pack-zh-CN
-jupyterlite==0.1.0b18
-jupyterlite-p5-kernel==0.1.0
+jupyterlite-core==0.1.0b20
+jupyterlite-p5-kernel==0.1.1
 
 # install the extra extensions
 .


### PR DESCRIPTION
The latest JupyterLite releases allow for depending on a smaller `jupyterlite-core` package that does not distribute the Pyodide and JavaScript kernels by default anymore:

- https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b19
- https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b20