### PR TITLE
Pin jupyterlab for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+        run: python -m pip install -U "jupyterlab>=4.0,<4.1"
 
       - name: Lint the extension
         run: |
@@ -74,7 +74,7 @@ jobs:
           sudo rm -rf $(which node)
           sudo rm -rf $(which node)
 
-          pip install "jupyterlab>=4.0.0,<5" p5_notebook*.whl
+          pip install "jupyterlab>=4.0,<4.1" p5_notebook*.whl
 
 
           jupyter labextension list

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,7 @@ set -xeu
 # install pixi
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
 ls -lisah ~
+echo $(basename "$SHELL")
 source ~/.bashrc
 
 pixi install

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,7 @@
 set -xeu
 
 touch ~/.bashrc
+touch ~/.bash_profile
 ls -lisah ~
 
 # install pixi
@@ -11,6 +12,7 @@ export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
 ls -lisah ~
 echo $(basename "$SHELL")
 source ~/.bashrc
+source ~/.bash_profile
 
 pixi install
 pixi run build_lite

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,6 +14,6 @@ echo $(basename "$SHELL")
 source ~/.bashrc
 source ~/.bash_profile
 
-pixi install
-pixi run build_lite
-pixi run copy_favicon
+~/.bin/pixi install
+~/.bin/pixi run build_lite
+~/.bin/pixi run copy_favicon

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,6 +14,6 @@ echo $(basename "$SHELL")
 source ~/.bashrc
 source ~/.bash_profile
 
-~/.bin/pixi install
-~/.bin/pixi run build_lite
-~/.bin/pixi run copy_favicon
+~/.pixi/bin/pixi install
+~/.pixi/bin/pixi run build_lite
+~/.pixi/bin/pixi run copy_favicon

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,7 @@ set -xeu
 # install pixi
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
 # source ~/.bashrc
+echo $SHELL
 ls -lisah ~
 
 pixi install

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ set -xeu
 
 # install pixi
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
-source ~/.bashrc
+# source ~/.bashrc
 ls -lisah ~
 
 pixi install

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,17 +3,14 @@
 # small script to deploy to Vercel
 set -xeu
 
-touch ~/.bashrc
-touch ~/.bash_profile
-ls -lisah ~
-
 # install pixi
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
-ls -lisah ~
-echo $(basename "$SHELL")
-source ~/.bashrc
-source ~/.bash_profile
 
+# This started to fail as of February 21st 2024
+# See commit log in https://github.com/jtpio/p5-notebook/pull/118
+# source ~/.bashrc
+
+# So explicitly pointing to the pixi binary instead
 ~/.pixi/bin/pixi install
 ~/.pixi/bin/pixi run build_lite
 ~/.pixi/bin/pixi run copy_favicon

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,7 @@ set -xeu
 # install pixi
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
 source ~/.bashrc
+ls -lisah ~
 
 pixi install
 pixi run build_lite

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,6 +3,9 @@
 # small script to deploy to Vercel
 set -xeu
 
+touch ~/.bashrc
+ls -lisah ~
+
 # install pixi
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
 ls -lisah ~

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,8 +4,8 @@
 set -xeu
 
 # install pixi
-touch ~/.bashrc
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
+ls -lisah ~
 source ~/.bashrc
 
 pixi install

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,10 +4,9 @@
 set -xeu
 
 # install pixi
+touch ~/.bashrc
 export PIXI_VERSION=v0.9.1 && curl -fsSL https://pixi.sh/install.sh | bash
-# source ~/.bashrc
-echo $SHELL
-ls -lisah ~
+source ~/.bashrc
 
 pixi install
 pixi run build_lite


### PR DESCRIPTION
Because of the `jlpm` change between and then revert in the JupyterLab 4.0.x series of releases.

Also fix the  Vercel deployment which started to fail (no way to source the `~/.bashrc` file anymore? :shrug:)